### PR TITLE
Add Openflow related RCs

### DIFF
--- a/doc/openflow_slice_factory_controller.rb
+++ b/doc/openflow_slice_factory_controller.rb
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+
+require 'omf_rc'
+require 'omf_rc/resource_factory'
+require 'omf_rc/resource_proxy/openflow_slice'
+require 'omf_rc/resource_proxy/openflow_slice_factory'
+
+$stdout.sync = true
+
+
+op_mode = :development
+
+opts = {
+  communication: { url: 'xmpp://flowvisor:pw@srv.mytestbed.net' },
+  eventloop: { type: :em },
+  logging: {
+    level: 'info'
+  #  level: 'debug',
+  #  appenders: {
+  #    stdout: {
+  #      date_pattern: '%H:%M:%S',
+  #      pattern: '%d %-5l %c{2}: %m\n',
+  #      color_scheme: 'default'
+  #    }
+  #  }
+  }
+}
+
+OmfCommon.init(op_mode, opts) do |el|
+  OmfCommon.comm.on_connected do |comm|
+    info ">>> Starting flowvisor"
+
+    flowvisor = OmfRc::ResourceFactory.new(:openflow_slice_factory, opts.merge(uid: 'flowvisor'))
+
+    # Disconnect garage from XMPP server, when INT or TERM signals received
+    comm.on_interrupted { flowvisor.disconnect }
+  end
+end

--- a/doc/openflow_slice_factory_test.rb
+++ b/doc/openflow_slice_factory_test.rb
@@ -1,0 +1,60 @@
+# OMF_VERSIONS = 6.0
+
+def create_slice(flowvisor)
+  flowvisor.create(:openflow_slice, {name: "test"}) do |reply_msg|
+    if !reply_msg.itype.start_with? "ERROR" #success?
+      slice = reply_msg.resource
+
+      slice.on_subscribed do
+        info ">>> Connected to newly created slice #{reply_msg[:res_id]} with name #{reply_msg[:name]}"
+        on_slice_created(slice)
+      end
+
+      after(10) do
+        flowvisor.release(slice) do |reply_msg|
+          info ">>> Released slice #{reply_msg[:res_id]}"
+        end
+      end
+    else
+      error ">>> Slice creation failed - #{reply_msg[:reason]}"
+    end
+  end
+end
+
+def on_slice_created(slice)
+
+  slice.request([:name]) do |reply_msg|
+    info "> Slice requested name: #{reply_msg[:name]}"
+  end
+
+  slice.configure(flows: [{operation: 'add', device: '00:00:00:00:00:00:00:01', eth_dst: '11:22:33:44:55:66'},
+                          {operation: 'add', device: '00:00:00:00:00:00:00:01', eth_dst: '11:22:33:44:55:77'}]) do |reply_msg|
+    info "> Slice configured flows:"
+    reply_msg.read_property('flows').each do |flow|
+      logger.info "   #{flow}"
+    end
+  end
+
+  # Monitor all status, error or warn information from the slice
+  #slice.on_status do |msg|
+  #  msg.each_property do |name, value|
+  #    info "#{name} => #{value}"
+  #  end
+  #end
+  slice.on_error do |msg|
+    error msg[:reason]
+  end
+  slice.on_warn do |msg|
+    warn msg[:reason]
+  end
+end
+
+OmfCommon.comm.subscribe('flowvisor') do |flowvisor|
+  unless flowvisor.error?
+    create_slice(flowvisor)
+  else
+    error flowvisor.inspect
+  end
+
+  after(20) { info 'Disconnecting ...'; OmfCommon.comm.disconnect }
+end

--- a/doc/virtual_openflow_switch_factory_controller.rb
+++ b/doc/virtual_openflow_switch_factory_controller.rb
@@ -1,0 +1,39 @@
+#!/usr/bin/env ruby
+
+require 'omf_rc'
+require 'omf_rc/resource_factory'
+require 'omf_rc/resource_proxy/virtual_openflow_switch'
+require 'omf_rc/resource_proxy/virtual_openflow_switch_factory'
+
+
+$stdout.sync = true
+
+
+op_mode = :development
+
+opts = {
+  communication: { url: 'xmpp://ovs:pw@srv.mytestbed.net' },
+  eventloop: { type: :em },
+  logging: {
+    level: 'info'
+  #  level: 'debug',
+  #  appenders: {
+  #    stdout: {
+  #      date_pattern: '%H:%M:%S',
+  #      pattern: '%d %-5l %c{2}: %m\n',
+  #      color_scheme: 'default'
+  #    }
+  #  }
+  }
+}
+
+OmfCommon.init(op_mode, opts) do |el|
+  OmfCommon.comm.on_connected do |comm|
+    info ">>> Starting ovs"
+
+    ovs = OmfRc::ResourceFactory.new(:virtual_openflow_switch_factory, opts.merge(uid: 'ovs'))
+
+    # Disconnect garage from XMPP server, when INT or TERM signals received
+    comm.on_interrupted { ovs.disconnect }
+  end
+end

--- a/doc/virtual_openflow_switch_factory_test.rb
+++ b/doc/virtual_openflow_switch_factory_test.rb
@@ -1,0 +1,60 @@
+# OMF_VERSIONS = 6.0
+
+#msgs = {
+#  request_port: @comm.request_message([port: {name: 'tun0', information: 'netdev-tunnel/get-port'}]),
+#  configure_port: @comm.configure_message([port: {name: 'tun0', remote_ip: '138.48.3.201', remote_port: '39505'}]),
+#}
+
+def create_switch(ovs)
+  ovs.create(:virtual_openflow_switch, {name: "test"}) do |reply_msg|
+    if !reply_msg.itype.start_with? "ERROR" #success?
+      switch = reply_msg.resource
+
+      switch.on_subscribed do
+        info ">>> Connected to newly created switch #{reply_msg[:res_id]} with name #{reply_msg[:name]}"
+        on_switch_created(switch)
+      end
+
+      after(10) do
+        ovs.release(switch) do |reply_msg|
+          info ">>> Released switch #{reply_msg[:res_id]}"
+        end
+      end
+    else
+      error ">>> Switch creation failed - #{reply_msg[:reason]}"
+    end
+  end
+end
+
+def on_switch_created(switch)
+
+  switch.configure(ports: {operation: 'add', name: 'tun0', type: 'tunnel'}) do |reply_msg|
+    info "> Switch configured ports: #{reply_msg[:ports]}"
+    switch.configure(port: {name: 'tun0', remote_ip: '138.48.3.201', remote_port: '39505'}) do |reply_msg|
+      info "> Switch configured port: #{reply_msg[:port]}"
+    end
+  end
+
+  # Monitor all status, error or warn information from the switch
+  #switch.on_status do |msg|
+  #  msg.each_property do |name, value|
+  #    info "#{name} => #{value}"
+  #  end
+  #end
+  switch.on_error do |msg|
+    error msg[:reason]
+  end
+  switch.on_warn do |msg|
+    warn msg[:reason]
+  end
+end
+
+OmfCommon.comm.subscribe('ovs') do |ovs|
+  unless ovs.error?
+    create_switch(ovs)
+  else
+    error ovs.inspect
+  end
+
+  after(20) { info 'Disconnecting ...'; OmfCommon.comm.disconnect }
+end

--- a/omf_rc/lib/omf_rc/resource_proxy/openflow_slice.rb
+++ b/omf_rc/lib/omf_rc/resource_proxy/openflow_slice.rb
@@ -1,0 +1,56 @@
+# This resource is created from the parent :openflow_slice_factory resource.
+# It is related with a slice of a flowvisor instance, and behaves as a proxy between experimenter and the actual flowvisor slice.
+#
+module OmfRc::ResourceProxy::OpenflowSlice
+  include OmfRc::ResourceProxyDSL
+
+
+  register_proxy :openflow_slice, :create_by => :openflow_slice_factory
+
+  utility :openflow_slice_tools
+
+  property :name, :default => nil
+
+
+  # Before release, the related flowvisor instance should also remove the corresponding slice
+  hook :before_release do |resource|
+    resource.flowvisor_connection.call("api.deleteSlice", resource.property.name)
+  end
+
+
+  # Configures the slice password
+  configure :passwd do |resource, passwd|
+    resource.flowvisor_connection.call("api.changePasswd", resource.property.name, passwd.to_s)
+    passwd.to_s
+  end
+
+  # Configures the slice parameters
+  [:contact_email, :drop_policy, :controller_hostname, :controller_port].each do |configure_sym|
+    configure configure_sym do |resource, value|
+      resource.flowvisor_connection.call("api.changeSlice", resource.property.name, configure_sym.to_s, value.to_s)
+      value.to_s
+    end
+  end
+
+  # Adds/removes a flow to this slice, specified by device, port, etc.
+  configure :flows do |resource, array_parameters|
+    array_parameters = [array_parameters] if !array_parameters.kind_of?(Array)
+    array_parameters.each do |parameters|
+      resource.flowvisor_connection.call("api.changeFlowSpace", resource.transformed_parameters(parameters))
+    end
+    resource.flows
+  end
+
+
+  # Returns a hash table with the name of this slice, its controller (ip and port) and other related information
+  request :info do |resource|
+    result = resource.flowvisor_connection.call("api.getSliceInfo", resource.property.name)
+    result[:name] = resource.property.name
+    result
+  end
+
+  # Returns a string with statistics about the use of this slice
+  request :stats do |resource|
+    resource.flowvisor_connection.call("api.getSliceStats", resource.property.name)
+  end
+end

--- a/omf_rc/lib/omf_rc/resource_proxy/openflow_slice_factory.rb
+++ b/omf_rc/lib/omf_rc/resource_proxy/openflow_slice_factory.rb
@@ -1,0 +1,77 @@
+# This resourse is related with a flowvisor instance and behaves as a proxy between experimenter and flowvisor.
+#
+module OmfRc::ResourceProxy::OpenflowSliceFactory
+  include OmfRc::ResourceProxyDSL
+
+  # The default arguments of the communication between this resource and the flowvisor instance
+  FLOWVISOR_CONNECTION_DEFAULTS = {
+    host:       "localhost",
+    path:       "/xmlrc",
+    port:       "8080",
+    proxy_host: nil,
+    proxy_port: nil,
+    user:       "fvadmin",
+    password:   "openflow",
+    use_ssl:    "true",
+    timeout:    nil
+  }
+
+  # The default parameters of a new slice. The openflow controller is assumed to be in the same working station with flowvisor instance
+  SLICE_DEFAULTS = {
+    passwd: "1234",
+    url:    "tcp:127.0.0.1:9933",
+    email:  "nothing@nowhere"
+  }
+
+
+  register_proxy :openflow_slice_factory
+
+  utility :openflow_slice_tools
+
+
+  # Checks if the created child is an :openflow_slice resource and passes the connection arguments that are essential for the connection with flowvisor instance
+  hook :before_create do |resource, type, opts|
+    if type.to_sym != :openflow_slice
+      raise "This resource doesn't create resources of type "+type
+    elsif opts.name == nil
+      raise "The created slice must be configured with a name"
+    end
+    #opts = Hashie::Mash.new(opts)
+    resource.flowvisor_connection.call("api.createSlice", opts.name.to_s, *SLICE_DEFAULTS.values)
+    opts.property ||= Hashie::Mash.new
+    opts.property.provider = ">> #{resource.uid}"
+    opts.property.flowvisor_connection_args = resource.property.flowvisor_connection_args
+  end
+
+  # A new resource uses the default connection arguments (ip adress, port, etc) to connect with a flowvisor instance
+  hook :before_ready do |resource|
+    resource.property.flowvisor_connection_args = FLOWVISOR_CONNECTION_DEFAULTS
+  end
+
+
+  # Configures the flowvisor connection arguments (ip adress, port, etc)
+  configure :flowvisor_connection do |resource, flowvisor_connection_args|
+    raise "Connection with a new flowvisor instance is not allowed if there exist created slices" if !resource.children.empty?
+    resource.property.flowvisor_connection_args.update(flowvisor_connection_args)
+  end
+
+
+  # Returns the flowvisor connection arguments (ip adress, port, etc)
+  request :flowvisor_connection do |resource|
+    resource.property.flowvisor_connection_args
+  end
+
+  # Returns a list of the existed slices or the connected devices
+  {:slices => "listSlices", :devices => "listDevices"}.each do |request_sym, handler_name|
+    request request_sym do |resource|
+      resource.flowvisor_connection.call("api.#{handler_name}")
+    end
+  end
+
+  # Returns information or statistics for a device specified by the given id
+  {:device_info => "getDeviceInfo", :device_stats => "getSwitchStats"}.each do |request_sym, handler_name|
+    request request_sym do |resource, device|
+      resource.flowvisor_connection.call("api.#{handler_name}", device.to_s)
+    end
+  end
+end

--- a/omf_rc/lib/omf_rc/resource_proxy/virtual_openflow_switch.rb
+++ b/omf_rc/lib/omf_rc/resource_proxy/virtual_openflow_switch.rb
@@ -1,0 +1,104 @@
+# This resource is created from the parent :virtual_openflow_switch_factory resource.
+# It is related with a bridge of an ovsdb-server instance, and behaves as a proxy between experimenter and the actual ovsdb-server bridge.
+#
+module OmfRc::ResourceProxy::VirtualOpenflowSwitch
+  include OmfRc::ResourceProxyDSL
+
+  register_proxy :virtual_openflow_switch, :create_by => :virtual_openflow_switch_factory
+
+  utility :virtual_openflow_switch_tools
+
+  property :name, :default => nil
+
+
+  # Before release, the related ovsdb-server instance should also remove the corresponding switch
+  hook :before_release do |resource|
+    arguments = {
+      "method" => "transact",
+      "params" => [ "Open_vSwitch",
+                    { "op" => "mutate",
+                      "table" => "Open_vSwitch",
+                      "where" => [],
+                      "mutations" => [["bridges", "delete", ["set", [["uuid", resource.property.uuid]]]]]
+                    },
+                    { "op" => "delete",
+                      "table" => "Bridge",
+                      "where" => [["name", "==", resource.property.name]],
+                    },
+                    { "op" => "delete",
+                      "table" => "Port",
+                      "where" => [["name", "==", resource.property.name]]
+                    },
+                    { "op" => "delete",
+                      "table" => "Interface",
+                      "where" => [["name", "==", resource.property.name]]
+                    }
+                  ],
+      "id" => "remove-switch"
+    }
+    resource.ovs_connection("ovsdb-server", arguments)
+  end
+
+
+  # Add/remove port
+  configure :ports do |resource, array_parameters|
+    array_parameters = [array_parameters] if !array_parameters.kind_of?(Array)
+    array_parameters.each do |parameters|
+      arguments = nil
+      if parameters.operation == "add"
+        arguments = {
+          "method" => "transact",
+          "params" => [ "Open_vSwitch",
+                        { "op" => "insert",
+                          "table" => "Interface",
+                          "row" => {"name" => parameters.name, "type" => parameters.type},
+                          "uuid-name" => "new_interface"
+                        },
+                        { "op" => "insert",
+                          "table" => "Port",
+                          "row" => {"name" => parameters.name, "interfaces" => ["named-uuid", "new_interface"]},
+                          "uuid-name" => "new_port"
+                        },
+                        { "op" => "mutate",
+                          "table" => "Bridge",
+                          "where" => [["name", "==", resource.property.name]],
+                          "mutations" => [["ports", "insert", ["set", [["named-uuid", "new_port"]]]]]
+                        }
+                      ],
+          "id" => "add-port"
+        }
+      elsif parameters.operation == "remove" # TODO: It is not filled
+      end
+      result = resource.ovs_connection("ovsdb-server", arguments)["result"]
+      raise "The configuration of the switch ports faced a problem" if result[3]
+    end
+    resource.ports
+  end
+
+  # Request port information (XXX: very restrictive, just to support our case)
+  request :port do |resource, parameters|
+    arguments = {
+      "method" => parameters.information,
+      "params" => [parameters.name],
+      "id" => "port-info"
+    }
+    resource.ovs_connection("ovs-vswitchd", arguments)["result"]
+  end
+
+  # Configure port (XXX: very restrictive, just to support our case)
+  configure :port do |resource, parameters|
+    arguments = {
+      "method" => "transact",
+      "params" => [ "Open_vSwitch",
+                    { "op" => "mutate",
+                      "table" => "Interface",
+                      "where" => [["name", "==", parameters.name]],
+                      "mutations" => [["options", "insert", ["map", 
+                         [["remote_ip", parameters.remote_ip], ["remote_port", parameters.remote_port.to_s]]]]]
+                    }
+                  ],
+      "id" => "configure-port"
+    }
+    resource.ovs_connection("ovsdb-server", arguments)["result"]
+  end
+end

--- a/omf_rc/lib/omf_rc/resource_proxy/virtual_openflow_switch_factory.rb
+++ b/omf_rc/lib/omf_rc/resource_proxy/virtual_openflow_switch_factory.rb
@@ -1,0 +1,97 @@
+# This resourse is related with an ovsdb-server (interface of an OVSDB database) and behaves as a proxy between experimenter and this.
+#
+module OmfRc::ResourceProxy::VirtualOpenflowSwitchFactory
+  include OmfRc::ResourceProxyDSL
+
+  # The default arguments of the communication between this resource and the ovsdb-server
+  OVS_CONNECTION_DEFAULTS = {
+    ovsdb_server_host:   "localhost",
+    ovsdb_server_port:   "6635",
+    ovsdb_server_socket: "/usr/local/var/run/openvswitch/db.sock",
+    ovsdb_server_conn:   "unix", # default "unix", between "tcp" and "unix"
+    ovs_vswitchd_pid:    "/usr/local/var/run/openvswitch/ovs-vswitchd.pid",
+    ovs_vswitchd_socket: "/usr/local/var/run/openvswitch/ovs-vswitchd.%s.ctl",
+    ovs_vswitchd_conn:   "unix" #default "unix", between "tcp" and "unix"
+  }
+
+
+  register_proxy :virtual_openflow_switch_factory
+
+  utility :virtual_openflow_switch_tools
+
+
+  # Checks if the created child is an :virtual_openflow_switch resource and passes the connection arguments
+  hook :before_create do |resource, type, opts|
+    if type.to_sym != :virtual_openflow_switch
+      raise "This resource doesn't create resources of type "+type
+    end
+    #opts = Hashie::Mash.new(opts)
+    arguments = {
+      "method" => "transact",
+      "params" => [ "Open_vSwitch",
+                    { "op" => "insert",
+                      "table" => "Interface",
+                      "row" => {"name" => opts.name.to_s, "type" => "internal"},
+                      "uuid-name" => "new_interface"
+                    },
+                    { "op" => "insert",
+                      "table" => "Port",
+                      "row" => {"name" => opts.name.to_s, "interfaces" => ["named-uuid", "new_interface"]},
+                      "uuid-name" => "new_port"
+                    },
+                    { "op" => "insert",
+                      "table" => "Bridge",
+                      "row" => {"name" => opts.name.to_s, "ports" => ["named-uuid", "new_port"], "datapath_type" => "netdev"},
+                      "uuid-name" => "new_bridge"
+                    },
+                    { "op" => "mutate",
+                      "table" => "Open_vSwitch",
+                      "where" => [],
+                      "mutations" => [["bridges", "insert", ["set", [["named-uuid", "new_bridge"]]]]]
+                    }
+                  ],
+      "id" => "add-switch"
+    }
+    result = resource.ovs_connection("ovsdb-server", arguments)["result"]
+    raise "The requested switch already existed in ovsdb-server or other problem" if result[4]
+    opts.property ||= Hashie::Mash.new
+    opts.property.provider = ">> #{resource.uid}"
+    opts.property.ovs_connection_args = resource.property.ovs_connection_args
+    opts.property.uuid = result[2]["uuid"][1]
+  end
+
+  # A new resource uses the default connection arguments (ip adress, port, socket, etc) to connect with a ovsdb-server instance
+  hook :before_ready do |resource|
+    resource.property.ovs_connection_args = OVS_CONNECTION_DEFAULTS
+  end
+
+
+  # Configures the ovsdb-server connection arguments (ip adress, port, socket, etc)
+  configure :ovs_connection do |resource, ovs_connection_args|
+    raise "Connection with a new ovsdb-server instance is not allowed if there exist created switches" if !resource.children.empty?
+    resource.property.ovs_connection_args.update(ovs_connection_args)
+  end
+
+
+  # Returns the ovsdb-server connection arguments (ip adress, port, socket, etc)
+  request :ovs_connection do |resource|
+    resource.property.ovs_connection_args
+  end
+
+  # Returns a list of virtual openflow switches, that correspond to the ovsdb-server bridges.
+  request :switches do |resource|
+    arguments = {
+      "method" => "transact", 
+      "params" => [ "Open_vSwitch", 
+                    { "op" => "select", 
+                      "table" => "Bridge", 
+                      "where" => [], 
+                      "columns" => ["name"]
+                    }
+                  ],
+      "id" => "switches"
+    }
+    result = resource.ovs_connection("ovsdb-server", arguments)["result"]
+    result[0]["rows"].map {|hash_name| hash_name["name"]}
+  end
+end

--- a/omf_rc/lib/omf_rc/util/openflow_slice_tools.rb
+++ b/omf_rc/lib/omf_rc/util/openflow_slice_tools.rb
@@ -1,0 +1,102 @@
+require 'xmlrpc/client'
+
+module OmfRc::Util::OpenflowSliceTools
+  include OmfRc::ResourceProxyDSL
+
+  # The version of the flowvisor that this resource is able to control 
+  FLOWVISOR_VERSION = "FV version=flowvisor-0.8.4"
+
+  # Parts of the regular expression that describes a flow entry for flowvisor
+  FLOWVISOR_FLOWENTRY_REGEXP_DEVIDED = [
+    /dpid=\[(?<device>.+)\]/,
+    /ruleMatch=\[OFMatch\[(?<match>.+)\]\]/,
+    /actionsList=\[Slice:(?<slice>.+)=(?<actions>.+)\]/,
+    /id=\[(?<id>.+)\]/,
+    /priority=\[(?<priority>.+)\]/
+  ]
+
+  # The regular expression that describes a flow entry for flowvisor
+  FLOWVISOR_FLOWENTRY_REGEXP = /FlowEntry\[#{FLOWVISOR_FLOWENTRY_REGEXP_DEVIDED.join(',')},\]/
+
+  # The names of the flow (or flow entry) features 
+  FLOW_FEATURES = %w{device match slice actions id priority}
+
+  # The names of the flow (or flow entry) features that are specified by the "match" feature
+  FLOW_MATCH_FEATURES = %w{in_port eth_src eth_dst ip_src ip_dst}
+
+  # The default features of a new flow (or flow entry)
+  FLOW_DEFAULTS = {
+    priority: "10",
+    actions:  "4"
+  }
+
+
+  # Returns the flows (flow entries) that exist for this flowvisor
+  request :flows do |resource, filter = nil|
+    resource.flows(filter)
+  end
+
+
+  # Internal function that creates a connection with a flowvisor instance and checks it
+  work :flowvisor_connection do |resource|
+    xmlrpc_client = XMLRPC::Client.new_from_hash(resource.property.flowvisor_connection_args)
+    xmlrpc_client.instance_variable_get("@http").verify_mode = OpenSSL::SSL::VERIFY_NONE
+    ping_msg = "test"
+    pong_msg = "PONG(#{resource.property.flowvisor_connection_args[:user]}): #{FLOWVISOR_VERSION}::#{ping_msg}"
+    raise "Connection with #{FLOWVISOR_VERSION} was not successful" if xmlrpc_client.call("api.ping", ping_msg) != pong_msg
+    xmlrpc_client
+  end
+
+  # Internal function that returns the flows (flow entries) that exist in the connected flowvisor instance
+  work :flows do |resource, filter = nil|
+    result = resource.flowvisor_connection.call("api.listFlowSpace")
+    result.map! do |line|
+      array_values = line.match(FLOWVISOR_FLOWENTRY_REGEXP)[1..-1]
+        # Example of above array's content: %w{00:00:...:01 in_port=1 test 4 30 10}  
+      array_features_values_zipped = FLOW_FEATURES.zip(array_values)
+        # Example of above array's content: %w{device 00:00:...:01 match in_port=1 slice test actions 4 id 30 priority 10}  
+      hash = Hashie::Mash.new(Hash[array_features_values_zipped])
+      # The following code adds extra features that are specified by the "match" feature
+      hash["match"].split(",").each do |couple|
+        array = couple.split("=")
+        hash[array[0]] = array[1]
+      end
+      hash
+    end
+    result.delete_if {|hash| hash["slice"] != resource.property.name} if resource.type.to_sym == :openflow_slice
+    FLOW_FEATURES.each do |feature| 
+      result.delete_if {|hash| hash[feature] != filter[feature].to_s} if filter[feature]
+    end if filter
+    result
+  end
+
+  work :transformed_parameters do |resource, parameters|
+    match = []
+    FLOW_MATCH_FEATURES.each do |feature|
+      match << "#{feature}=#{parameters[feature]}" if parameters[feature]
+    end
+    match = match.join(",")
+
+    result = []
+    case parameters.operation
+    when "add"
+      h = Hashie::Mash.new
+      h.operation = parameters.operation.upcase
+      h.priority  = parameters.priority ? parameters.priority.to_s : FLOW_DEFAULTS[:priority]
+      h.dpid      = parameters.device.to_s
+      h.actions   = "Slice:#{resource.property.name}=#{(parameters.actions ? parameters.actions : FLOW_DEFAULTS[:actions])}"
+      h.match     = "OFMatch[#{match}]"
+      result << h
+    when "remove"
+      resource.flows(parameters).each do |f|
+        if f.match == match 
+          h = Hashie::Mash.new
+          h.operation = parameters.operation.upcase
+          h.id = f.id
+          result << h
+        end 
+      end    
+    end
+    result
+  end
+end

--- a/omf_rc/lib/omf_rc/util/virtual_openflow_switch_tools.rb
+++ b/omf_rc/lib/omf_rc/util/virtual_openflow_switch_tools.rb
@@ -1,0 +1,62 @@
+module OmfRc::Util::VirtualOpenflowSwitchTools
+  include OmfRc::ResourceProxyDSL
+
+  # Internal function that returns a hash result of the json-request to the ovsdb-server or the ovs-switchd instances
+  work :ovs_connection do |resource, target, arguments|
+    stream = nil
+    if target == "ovsdb-server"
+      if resource.property.ovs_connection_args.ovsdb_server_conn == "tcp"
+        stream = TCPSocket.new(resource.property.ovs_connection_args.ovsdb_server_host, 
+                               resource.property.ovs_connection_args.ovsdb_server_port)
+      elsif resource.property.ovs_connection_args.ovsdb_server_conn == "unix"
+        stream = UNIXSocket.new(resource.property.ovs_connection_args.ovsdb_server_socket)
+      end
+    elsif target == "ovs-vswitchd"
+      if resource.property.ovs_connection_args.ovs_vswitchd_conn == "unix"
+        file = File.new(resource.property.ovs_connection_args.ovs_vswitchd_pid, "r")
+        pid = file.gets.chomp
+        file.close
+        socket = resource.property.ovs_connection_args.ovs_vswitchd_socket % [pid]
+        stream = UNIXSocket.new(socket)
+      end
+    end
+    stream.puts(arguments.to_json)
+    string = stream.gets('{')
+    counter = 1 # number of read '['
+    while counter > 0
+      char = stream.getc
+      if char == '{'
+        counter += 1
+      elsif char == '}'
+        counter -= 1
+      end
+      string += char
+    end
+    stream.close
+    JSON.parse(string)
+  end
+
+  # Internal function that returns the ports of a specific switch
+  work :ports do |resource|
+    arguments = {
+      "method" => "transact", 
+      "params" => [ "Open_vSwitch", 
+                    { "op" => "select", 
+                      "table" => "Bridge", 
+                      "where" => [["name", "==", resource.property.name]], 
+                      "columns" => ["ports"]
+                    },
+                    { "op" => "select", 
+                      "table" => "Port", 
+                      "where" => [], 
+                      "columns" => ["name", "_uuid"]
+                    }
+                  ],
+      "id" => "ports"
+    }
+    result = resource.ovs_connection("ovsdb-server", arguments)["result"]
+    uuid2name = Hash[result[1]["rows"].map {|hash_uuid_name| [hash_uuid_name["_uuid"][1], hash_uuid_name["name"]]}]
+    uuids = result[0]["rows"][0]["ports"][1].map {|array_uuid| array_uuid[1]}
+    uuids.map {|v| uuid2name[v]}
+  end
+end


### PR DESCRIPTION
Two remarks:
1. I guess that function "success?" in file omf/omf_common/lib/omf_common/message.rb is wrongly defined, since the word "error" should be replaced by the word "ERROR".
2. The line "opts = Hashie::Mash.new(opts)" does not work properly if I comment out it in the hook ":before_create" in the factory RCs
3. One more time, I note that you should replace "OmfRc::ResourceFactory.load_addtional_resource_proxies" with "OmfRc::ResourceFactory.load_additional_resource_proxies"
