### PR TITLE
Restore OMF-5 backward compatibility

### DIFF
--- a/omf_ec/lib/omf_ec/context/app_context.rb
+++ b/omf_ec/lib/omf_ec/context/app_context.rb
@@ -24,11 +24,6 @@ module OmfEc::Context
       end
     end
 
-    def bindProperty(key, property_value)
-      warn_deprecation :bindProperty, :setProperty
-      setProperty(key, property_value)
-    end
-
     def setProperty(key, property_value)
       app_def_param = app_def.properties.parameters
       raise OEDLUnknownProperty.new(key, "Unknown parameter '#{key}' for application "+


### PR DESCRIPTION
- Map old bindProperty to setProperty, and issue a warning that it is deprecated;
- Don't complain about 'version' is deprecated and not supported;
- Use path instead of bin_path;

fixes: #1804

http://oml.mytestbed.net/issues/1804

Signed-off-by: Olivier Mehani olivier.mehani@nicta.com.au
