### PR TITLE
Fix amqp gem version to 1.5.3

### DIFF
--- a/omf_common/omf_common.gemspec
+++ b/omf_common/omf_common.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logging", "~> 1.8.2"
   s.add_runtime_dependency "hashie"
   s.add_runtime_dependency "oml4r", "~> 2.10.1"
-  s.add_runtime_dependency "amqp"
+  s.add_runtime_dependency "amqp", "= 1.5.3"
   s.add_runtime_dependency "uuidtools"
 
   s.add_runtime_dependency "oj"


### PR DESCRIPTION
- Versions 1.6.0 and later require Ruby 2.0.0 or greater, and break the
  current setup
- Fixes #12